### PR TITLE
Fix GetTaskExitStatus success criteria - allowing WARNINGS exit status

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -472,7 +472,10 @@ func (c *Client) WaitForCompletion(taskResponse map[string]interface{}) (waitExi
 	return "", fmt.Errorf("Wait timeout for:" + taskUpid)
 }
 
-var rxTaskNode = regexp.MustCompile("UPID:(.*?):")
+var (
+	rxTaskNode          = regexp.MustCompile("UPID:(.*?):")
+	rxExitStatusSuccess = regexp.MustCompile(`^(OK|WARNINGS)`)
+)
 
 func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err error) {
 	node := rxTaskNode.FindStringSubmatch(taskUpid)[1]
@@ -482,7 +485,7 @@ func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err
 	if err == nil {
 		exitStatus = data["data"].(map[string]interface{})["exitstatus"]
 	}
-	if exitStatus != nil && exitStatus != exitStatusSuccess {
+	if exitStatus != nil && rxExitStatusSuccess.FindString(exitStatus.(string)) == "" {
 		err = fmt.Errorf(exitStatus.(string))
 	}
 	return


### PR DESCRIPTION
Proxmox changed its API in March 2024.
Up until that point, when trying to create multiple VMs in parallel from a template it raised an error `can't deactivate LV` because the logical volume was still in use by the other VMs. That error got downgraded to a warning, which means that the clone tasks will be completed successfully. Therefore, we need to mark this as a successful task.

See the following:
* https://lists.proxmox.com/pipermail/pve-devel/2024-March/062115.html
* https://github.com/Telmate/proxmox-api-go/commit/e79247d189085f2e20426a85a9748701b1816129

Those code changes are identical to the changes in the original Telmate repository (good-old "copy-paste", there is no reason to reinvent the wheel).