### PR TITLE
P81-113820 chore(security): pin 3rd party actions to SHA commits [skip actions]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,10 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: '1.19'
         check-latest: true


### PR DESCRIPTION
## Describe your changes

Pin all 3rd party GitHub Actions to full SHA commit hashes to prevent supply-chain attacks.

### What was done:
- **SHA pinning**: Replaced version tags (e.g., `@v4`) with full SHA commits — versions NOT upgraded
- **Zizmor compliance**: Added `# zizmor: ignore[unpinned-uses]` to all internal `perimeter-81/actions/...` refs

### External actions pinned (2):
- `actions/checkout@v2` → `@ee0669bd1cc54295...`
- `actions/setup-go@v2` → `@bfdd3570ce990073...`

## Jira ticket
_(none)_

## Tests
- All YAML files pass `yaml.safe_load()` validation
- No remaining 3rd party actions using version tags (verified)
- No remaining internal actions missing `# zizmor: ignore[unpinned-uses]`

## Checklist
- [x] Self-review performed
- [x] All 3rd party actions pinned to SHA commits (not version tags)
- [x] Versions NOT upgraded — only pinned to existing tag's SHA
