### PR TITLE
[skip actions] P81-121027 Migrate to self-hosted runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ACTIONS_RUNNER }}
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 


### PR DESCRIPTION
Jira: https://perimeter81.atlassian.net/browse/P81-121027

## Changes

Migrated all workflow `runs-on` values to use `${{ vars.ACTIONS_RUNNER }}`.

Runner selected because: repository does not require Docker-in-Docker.

## Modified workflow files

- `.github/workflows/go.yml`

---
Co-authored-by: Claude (claude-sonnet-4-6)